### PR TITLE
snap.auxdata.properties file not included in installation

### DIFF
--- a/snap.install4j
+++ b/snap.install4j
@@ -48,6 +48,7 @@
     <entries>
       <fileEntry mountPoint="611" file="./images/SNAP_Icon_48.png" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="646" file="../snap-desktop/snap-application/target/snap/etc/snap.clusters" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="646" file="../snap-engine/etc/snap.auxdata.properties" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="646" file="../snap-engine/etc/snap.properties" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <fileEntry mountPoint="1017" file="../snap-desktop/snap-main/target/snap-main.jar" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <dirEntry mountPoint="58" file="../snap-desktop/snap-application/target/snap/snap" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="subdir" subDirectory="snap" excludeSuffixes="" dirMode="755" overrideDirMode="false">


### PR DESCRIPTION
The "snap-engine/etc/snap.auxdata.properties" was missing from the installation, so I re-added it. I suppose it might have been left out on purpose to deprecate it, but right now this breaks the Apply-Orbit-File operator (and only that). The code for locating and downloading DEM files also uses these settings but has appropriate default values set in the code, so it is not affected.