### PR TITLE
Escape variables in snap.conf

### DIFF
--- a/snap.install4j
+++ b/snap.install4j
@@ -689,6 +689,9 @@ return success;
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">
                     <object class="com.install4j.runtime.beans.actions.text.ReplaceInstallerVariablesAction">
+                      <void property="escapeForPropertyFile">
+                        <boolean>true</boolean>
+                      </void>
                       <void property="files">
                         <array class="java.io.File" length="1">
                           <void index="0">


### PR DESCRIPTION
Windows paths are currently being read incorrectly from etc/snap.conf due to unescaped backslashes.