### PR TITLE
[SNAP-1367] Azul JDK does not include fonts

### DIFF
--- a/snap.install4j
+++ b/snap.install4j
@@ -10,6 +10,7 @@
       <variable name="snapGptMenuName" value="SNAP GPT" />
       <variable name="smosGridPointExporter" value="smos-grid-point-exporter" />
     </variables>
+    <jreBundles jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u292-b10" />
   </application>
   <files missingFilesStrategy="error" defaultUninstallMode="2" launcherOverwriteMode="1">
     <filesets>
@@ -1650,7 +1651,7 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="windows-amd64-1.8.0.242" />
+      <jreBundle jreBundleSource="generated" includedJre="windows-amd64-1.8.0.242" />
     </windows>
     <windows name="All SNAP Windows x86" id="2584" mediaFileName="${compiler:sys.shortName}_all_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" jreBitType="32" downloadURL="http://step.esa.int/downloads/2.0" includeAllDownloadableComponents="true">
       <excludedLaunchers>
@@ -1664,7 +1665,7 @@ return console.askYesNo(message, true);
         <entry filesetId="639" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="windows-x86-1.8.0.242" />
+      <jreBundle jreBundleSource="generated" includedJre="windows-x86-1.8.0.242" />
     </windows>
     <macosFolder name="All SNAP Mac OS X Folder" id="2575" mediaFileName="${compiler:sys.shortName}_all_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0" includeAllDownloadableComponents="true">
       <excludedLaunchers>
@@ -1678,7 +1679,7 @@ return console.askYesNo(message, true);
         <entry filesetId="639" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="macosx-amd64-1.8.0.242" />
+      <jreBundle jreBundleSource="generated" includedJre="macosx-amd64-1.8.0.242" />
     </macosFolder>
     <unixInstaller name="All SNAP Unix" id="2578" mediaFileName="${compiler:sys.shortName}_all_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0" includeAllDownloadableComponents="true">
       <excludedLaunchers>
@@ -1691,7 +1692,7 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="639" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="linux-amd64-1.8.0.242" />
+      <jreBundle jreBundleSource="generated" includedJre="linux-amd64-1.8.0.242" />
     </unixInstaller>
     <windows name="Sentinel SNAP Windows x64" id="2589" mediaFileName="${compiler:sys.shortName}_sentinel_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1717,7 +1718,7 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="windows-amd64-1.8.0.242" />
+      <jreBundle jreBundleSource="generated" includedJre="windows-amd64-1.8.0.242" />
     </windows>
     <windows name="Sentinel SNAP Windows x86" id="2603" mediaFileName="${compiler:sys.shortName}_sentinel_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" jreBitType="32" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1743,7 +1744,7 @@ return console.askYesNo(message, true);
         <entry filesetId="639" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="windows-x86-1.8.0.242" />
+      <jreBundle jreBundleSource="generated" includedJre="windows-x86-1.8.0.242" />
     </windows>
     <macosFolder name="Sentinel SNAP Mac OS X Folder" id="2592" mediaFileName="${compiler:sys.shortName}_sentinel_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1769,7 +1770,7 @@ return console.askYesNo(message, true);
         <entry filesetId="639" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="macosx-amd64-1.8.0.242" />
+      <jreBundle jreBundleSource="generated" includedJre="macosx-amd64-1.8.0.242" />
     </macosFolder>
     <unixInstaller name="Sentinel SNAP Unix" id="2598" mediaFileName="${compiler:sys.shortName}_sentinel_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1794,7 +1795,7 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="639" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="linux-amd64-1.8.0.242" />
+      <jreBundle jreBundleSource="generated" includedJre="linux-amd64-1.8.0.242" />
     </unixInstaller>
     <windows name="SMOS SNAP Windows x64" id="2609" mediaFileName="${compiler:sys.shortName}_smos_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1825,7 +1826,7 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="windows-amd64-1.8.0.242" />
+      <jreBundle jreBundleSource="generated" includedJre="windows-amd64-1.8.0.242" />
     </windows>
     <windows name="SMOS SNAP Windows x86" id="2620" mediaFileName="${compiler:sys.shortName}_smos_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" jreBitType="32" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1856,7 +1857,7 @@ return console.askYesNo(message, true);
         <entry filesetId="639" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="windows-x86-1.8.0.242" />
+      <jreBundle jreBundleSource="generated" includedJre="windows-x86-1.8.0.242" />
     </windows>
     <macosFolder name="SMOS SNAP Mac OS X Folder" id="2612" mediaFileName="${compiler:sys.shortName}_smos_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1887,7 +1888,7 @@ return console.askYesNo(message, true);
         <entry filesetId="639" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="macosx-amd64-1.8.0.242" />
+      <jreBundle jreBundleSource="generated" includedJre="macosx-amd64-1.8.0.242" />
     </macosFolder>
     <unixInstaller name="SMOS SNAP Unix" id="2617" mediaFileName="${compiler:sys.shortName}_smos_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1917,7 +1918,7 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="639" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="linux-amd64-1.8.0.242" />
+      <jreBundle jreBundleSource="generated" includedJre="linux-amd64-1.8.0.242" />
     </unixInstaller>
     <unixArchive name="Engine Unix Archive" id="859" installDir="snap">
       <excludedLaunchers>
@@ -1937,7 +1938,7 @@ return console.askYesNo(message, true);
       </exclude>
     </unixArchive>
   </mediaSets>
-  <buildIds>
+  <buildIds buildAll="false">
     <mediaSet refId="2571" />
     <mediaSet refId="2575" />
     <mediaSet refId="2578" />


### PR DESCRIPTION
Does not fix the font issue but updates JRE to latest update.

The font issue seems to be common for all OpenJDK distributions