### PR TITLE
add linux aarch64 build & support for AdoptOpenJDK

### DIFF
--- a/snap.install4j
+++ b/snap.install4j
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<install4j version="8.0.5" transformSequenceNumber="8">
+<install4j version="8.0.11" transformSequenceNumber="8">
   <directoryPresets config="../snap-desktop/snap-application/target/snap/THIRDPARTY_LICENSES.txt" />
   <application name="ESA SNAP" applicationId="0941-5747-6134-5911" mediaDir="./target" compression="9" commonExternalFiles="true" shrinkRuntime="false" shortName="esa-snap" publisher="European Space Agency" publisherWeb="http://www.esa.int/ESA" version="9.0.0-SNAPSHOT" allPathsRelative="true" macVolumeId="69e291547ea53333" javaMinVersion="1.8" allowBetaVM="true" jdkMode="jdk">
     <variables>
@@ -10,6 +10,7 @@
       <variable name="snapGptMenuName" value="SNAP GPT" />
       <variable name="smosGridPointExporter" value="smos-grid-point-exporter" />
     </variables>
+    <jreBundles jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" />
   </application>
   <files missingFilesStrategy="error" defaultUninstallMode="2" launcherOverwriteMode="1">
     <filesets>
@@ -1650,7 +1651,11 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="windows-amd64-1.8.0.242" />
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true" jreBundleSource="generated">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </windows>
     <windows name="All SNAP Windows x86" id="2584" mediaFileName="${compiler:sys.shortName}_all_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" jreBitType="32" downloadURL="http://step.esa.int/downloads/2.0" includeAllDownloadableComponents="true">
       <excludedLaunchers>
@@ -1664,7 +1669,11 @@ return console.askYesNo(message, true);
         <entry filesetId="639" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="windows-x86-1.8.0.242" />
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true" jreBundleSource="generated">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </windows>
     <macosFolder name="All SNAP Mac OS X Folder" id="2575" mediaFileName="${compiler:sys.shortName}_all_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0" includeAllDownloadableComponents="true">
       <excludedLaunchers>
@@ -1678,7 +1687,11 @@ return console.askYesNo(message, true);
         <entry filesetId="639" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="macosx-amd64-1.8.0.242" />
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true" jreBundleSource="generated">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </macosFolder>
     <unixInstaller name="All SNAP Unix" id="2578" mediaFileName="${compiler:sys.shortName}_all_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0" includeAllDownloadableComponents="true">
       <excludedLaunchers>
@@ -1691,7 +1704,11 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="639" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="linux-amd64-1.8.0.242" />
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true" jreBundleSource="generated">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </unixInstaller>
     <windows name="Sentinel SNAP Windows x64" id="2589" mediaFileName="${compiler:sys.shortName}_sentinel_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1717,7 +1734,11 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="windows-amd64-1.8.0.242" />
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true" jreBundleSource="generated" includedJre="/home/vscode/.install4j8/jres/zulu8.60.0.21-ca-jdk8.0.322-win_x64.zip" manualJreEntry="true">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </windows>
     <windows name="Sentinel SNAP Windows x86" id="2603" mediaFileName="${compiler:sys.shortName}_sentinel_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" jreBitType="32" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1743,7 +1764,11 @@ return console.askYesNo(message, true);
         <entry filesetId="639" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="windows-x86-1.8.0.242" />
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true" jreBundleSource="generated">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </windows>
     <macosFolder name="Sentinel SNAP Mac OS X Folder" id="2592" mediaFileName="${compiler:sys.shortName}_sentinel_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1769,7 +1794,11 @@ return console.askYesNo(message, true);
         <entry filesetId="639" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="macosx-amd64-1.8.0.242" />
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true" jreBundleSource="generated">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </macosFolder>
     <unixInstaller name="Sentinel SNAP Unix" id="2598" mediaFileName="${compiler:sys.shortName}_sentinel_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1794,7 +1823,11 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="639" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="linux-amd64-1.8.0.242" />
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true" jreBundleSource="generated">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </unixInstaller>
     <windows name="SMOS SNAP Windows x64" id="2609" mediaFileName="${compiler:sys.shortName}_smos_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1825,7 +1858,11 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="windows-amd64-1.8.0.242" />
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </windows>
     <windows name="SMOS SNAP Windows x86" id="2620" mediaFileName="${compiler:sys.shortName}_smos_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" jreBitType="32" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1856,7 +1893,11 @@ return console.askYesNo(message, true);
         <entry filesetId="639" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="windows-x86-1.8.0.242" />
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </windows>
     <macosFolder name="SMOS SNAP Mac OS X Folder" id="2612" mediaFileName="${compiler:sys.shortName}_smos_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1887,7 +1928,11 @@ return console.askYesNo(message, true);
         <entry filesetId="639" />
         <entry filesetId="641" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="macosx-amd64-1.8.0.242" />
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </macosFolder>
     <unixInstaller name="SMOS SNAP Unix" id="2617" mediaFileName="${compiler:sys.shortName}_smos_${compiler:sys.platform}_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
       <excludedComponents>
@@ -1917,7 +1962,11 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="639" />
       </exclude>
-      <jreBundle jreBundleSource="preCreated" includedJre="linux-amd64-1.8.0.242" />
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true" jreBundleSource="generated">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </unixInstaller>
     <unixArchive name="Engine Unix Archive" id="859" installDir="snap">
       <excludedLaunchers>
@@ -1935,12 +1984,63 @@ return console.askYesNo(message, true);
         <entry filesetId="637" />
         <entry filesetId="639" />
       </exclude>
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true" jreBundleSource="generated">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
     </unixArchive>
+    <unixInstaller name="Sentinel SNAP Unix ARM64" id="3623" mediaFileName="${compiler:sys.shortName}_sentinel_${compiler:sys.platform}_aarch64_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0">
+      <excludedComponents>
+        <component id="1963" />
+        <component id="3109" />
+      </excludedComponents>
+      <includedDownloadableComponents>
+        <component id="73" />
+        <component id="72" />
+        <component id="68" />
+        <component id="306" />
+      </includedDownloadableComponents>
+      <excludedLaunchers>
+        <launcher id="538" />
+        <launcher id="618" />
+        <launcher id="656" />
+        <launcher id="2822" />
+      </excludedLaunchers>
+      <exclude>
+        <entry location="smos" />
+        <entry filesetId="634" />
+        <entry filesetId="637" />
+        <entry filesetId="639" />
+      </exclude>
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true" jreBundleSource="generated" platform="linux-aarch64">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
+    </unixInstaller>
+    <unixInstaller name="All SNAP Unix ARM64" id="3626" mediaFileName="${compiler:sys.shortName}_all_${compiler:sys.platform}_aarch64_${compiler:sys.version}" installDir="snap" downloadURL="http://step.esa.int/downloads/2.0" includeAllDownloadableComponents="true">
+      <excludedLaunchers>
+        <launcher id="538" />
+        <launcher id="618" />
+        <launcher id="656" />
+      </excludedLaunchers>
+      <exclude>
+        <entry filesetId="634" />
+        <entry filesetId="637" />
+        <entry filesetId="639" />
+      </exclude>
+      <jreBundle jdkProviderId="AdoptOpenJDK" release="openjdk8/jdk8u322-b06" overrideJdkRelease="true" jreBundleSource="generated" platform="linux-aarch64">
+        <modules>
+          <defaultModules set="jre" />
+        </modules>
+      </jreBundle>
+    </unixInstaller>
   </mediaSets>
   <buildIds>
     <mediaSet refId="2571" />
     <mediaSet refId="2575" />
     <mediaSet refId="2578" />
   </buildIds>
-  <buildOptions faster="true" disableSigning="true" />
+  <buildOptions verbose="true" faster="true" disableSigning="true" />
 </install4j>


### PR DESCRIPTION
It packages JDK via AdoptOpenJDK using install4j built-in setup. In addition, added support for ARM64 (aarch64).